### PR TITLE
Fix comment typos.

### DIFF
--- a/BestPractices/Source/Detail/Factories/DetailCoordinatorFactory.swift
+++ b/BestPractices/Source/Detail/Factories/DetailCoordinatorFactory.swift
@@ -2,7 +2,7 @@
 ///
 /// This class also stores the view model / controller factories for the detail flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class DetailCoordinatorFactory {
 

--- a/BestPractices/Source/Detail/Factories/DetailViewControllerFactory.swift
+++ b/BestPractices/Source/Detail/Factories/DetailViewControllerFactory.swift
@@ -2,7 +2,7 @@ import Core
 
 /// A factory for creating view controllers for the detail flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view controller's dependencies.
 class DetailViewControllerFactory: DetailNavigationControllerFactory {
 

--- a/BestPractices/Source/Detail/Factories/DetailViewModelFactory.swift
+++ b/BestPractices/Source/Detail/Factories/DetailViewModelFactory.swift
@@ -1,5 +1,5 @@
 /// A factory for creating view models for detail flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class DetailViewModelFactory: DetailNavigationModelFactory { }

--- a/BestPractices/Source/Home/Factories/HomeCoordinatorFactory.swift
+++ b/BestPractices/Source/Home/Factories/HomeCoordinatorFactory.swift
@@ -2,7 +2,7 @@
 ///
 /// This class also stores the view model / controller factories for the home flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class HomeCoordinatorFactory {
 

--- a/BestPractices/Source/Home/Factories/HomeViewControllerFactory.swift
+++ b/BestPractices/Source/Home/Factories/HomeViewControllerFactory.swift
@@ -2,7 +2,7 @@ import Core
 
 /// A factory for creating view controllers for the home flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view controller's dependencies.
 class HomeViewControllerFactory: HomeNavigationControllerFactory {
 

--- a/BestPractices/Source/Home/Factories/HomeViewModelFactory.swift
+++ b/BestPractices/Source/Home/Factories/HomeViewModelFactory.swift
@@ -1,5 +1,5 @@
 /// A factory for creating view models for home flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class HomeViewModelFactory: HomeNavigationModelFactoryProtocol { }

--- a/BestPractices/Source/Home/View/HomeViewModel.swift
+++ b/BestPractices/Source/Home/View/HomeViewModel.swift
@@ -10,7 +10,7 @@ class HomeViewModel: ViewModel, DetailPresentingViewModel {
 
     weak var detailPresenter: DetailPresenter?
 
-    /// Example text that will be updated asynchonously when isActive becomes true.
+    /// Example text that will be updated asynchronously when isActive becomes true.
     let testText: Property<String?>
     let image = Property(value: Image.n8churLogo.image)
     let presentDetailTitle = Property(value: L10n.Home.PresentDetail.title)

--- a/BestPractices/Source/Root/Factories/RootCoordinatorFactory.swift
+++ b/BestPractices/Source/Root/Factories/RootCoordinatorFactory.swift
@@ -2,7 +2,7 @@
 ///
 /// This class also stores the view model / controller factories for the root.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class RootCoordinatorFactory {
 

--- a/BestPractices/Source/Root/Factories/RootViewControllerFactory.swift
+++ b/BestPractices/Source/Root/Factories/RootViewControllerFactory.swift
@@ -3,7 +3,7 @@ import Core
 
 /// A factory for creating view controllers for the root of the application.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view controller's dependencies.
 class RootViewControllerFactory {
 

--- a/BestPractices/Source/Root/Factories/RootViewModelFactory.swift
+++ b/BestPractices/Source/Root/Factories/RootViewModelFactory.swift
@@ -2,7 +2,7 @@ import Core
 
 /// A factory for creating view models for root of the application.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class RootViewModelFactory {
 

--- a/BestPractices/Source/Selection/SelectionViewModel.swift
+++ b/BestPractices/Source/Selection/SelectionViewModel.swift
@@ -20,12 +20,12 @@ class SelectionViewModel: ResultViewModel {
 
     /// The input for the selection.
     ///
-    /// The value of this property will be sent as a value in the submit action's exectution signal.
+    /// The value of this property will be sent as a value in the submit action's execution signal.
     ///
     /// This should be bound to the input field.
     let input = MutableProperty<Result>(nil)
 
-    /// Sends the value of input when exectuted.
+    /// Sends the value of input when executed.
     private(set) lazy var submit = Action<(), Result, NoError> { [weak self] in
         guard let self = self else { fatalError() }
 

--- a/BestPractices/Source/Settings/Factories/SettingsCoordinatorFactory.swift
+++ b/BestPractices/Source/Settings/Factories/SettingsCoordinatorFactory.swift
@@ -2,7 +2,7 @@
 ///
 /// This class also stores the view model / controller factories for the settings flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class SettingsCoordinatorFactory {
 

--- a/BestPractices/Source/Settings/Factories/SettingsViewControllerFactory.swift
+++ b/BestPractices/Source/Settings/Factories/SettingsViewControllerFactory.swift
@@ -2,7 +2,7 @@ import Core
 
 /// A factory for creating view controllers for the settings flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view controller's dependencies.
 class SettingsViewControllerFactory: SettingsNavigationControllerFactory {
 

--- a/BestPractices/Source/Settings/Factories/SettingsViewModelFactory.swift
+++ b/BestPractices/Source/Settings/Factories/SettingsViewModelFactory.swift
@@ -2,7 +2,7 @@ import Core
 
 /// A factory for creating view models for settings flow.
 ///
-/// This class' purpose is mainly to clean up dependency injection by taking that reponsibility from classes that should
+/// This class' purpose is mainly to clean up dependency injection by taking that responsibility from classes that should
 /// not have knowledge of each of its view model's dependencies.
 class SettingsViewModelFactory: SettingsNavigationModelFactory {
 

--- a/Logger/Source/Log.swift
+++ b/Logger/Source/Log.swift
@@ -41,7 +41,7 @@ public struct Logger {
 
         private var list: [Context] = []
 
-        /// Retuns an existing Context for the provided identifier if it exists,
+        /// Returns an existing Context for the provided identifier if it exists,
         /// otherwise creates a new Context and returns it.
         public func context(_ identifier: Context.Identifier) -> Context {
             if let context = list.first(where: { $0.identifier == identifier }) {
@@ -71,7 +71,7 @@ public struct Logger {
 
     public static let shared = Logger()
 
-    /// The context manager reponsible for creating new contexts for logging.
+    /// The context manager responsible for creating new contexts for logging.
     public let contextManager = ContextManager()
 
     private let fileLogger: DDFileLogger

--- a/Presentations/Source/Extensions/UIKit/UINavigationController.swift
+++ b/Presentations/Source/Extensions/UIKit/UINavigationController.swift
@@ -19,7 +19,7 @@ extension Reactive where Base: UINavigationController {
 
     /// The execution signal sends no values and completes when the view controller has finished popping.
     ///
-    /// This will also pop any view controllers pushed after the view controller bieng popped.
+    /// This will also pop any view controllers pushed after the view controller being popped.
     ///
     /// Calling this on the root view controller does nothing and the action complete immediately.
     public var popViewController: Action<(UIViewController, Bool), Never, NoError> {

--- a/Presentations/Source/Extensions/UIKit/UIViewController+Presentations.swift
+++ b/Presentations/Source/Extensions/UIKit/UIViewController+Presentations.swift
@@ -40,7 +40,7 @@ public extension UIViewController {
 
 public extension DismissablePresentationContext {
 
-    /// Sets the left navigation item to be a cancel button that executes the dimiss action.
+    /// Sets the left navigation item to be a cancel button that executes the dismiss action.
     ///
     /// - Parameter viewController: The view controller to add the navigation item to.
     public func addCancelBarButtonItem(to viewController: UIViewController) {

--- a/Presentations/Source/PresentationContext.swift
+++ b/Presentations/Source/PresentationContext.swift
@@ -5,7 +5,7 @@ import ReactiveExtensions
 
 /// A context for a presentation.
 ///
-/// Contains additional information about a presentation in a specific presentation, like whether or not the presenation
+/// Contains additional information about a presentation in a specific presentation, like whether or not the presentation
 /// and dismissal should be animated.
 public class DismissablePresentationContext {
 
@@ -21,7 +21,7 @@ public class DismissablePresentationContext {
 
 }
 
-/// A dismissable presentation that dismisses when the provided result view model's result signal sends a value.
+/// A dismissible presentation that dismisses when the provided result view model's result signal sends a value.
 public class ResultPresentationContext<ViewModel: ResultViewModel>: DismissablePresentationContext {
 
     public let viewModel: ViewModel

--- a/Presentations/Source/Presention.swift
+++ b/Presentations/Source/Presention.swift
@@ -2,7 +2,7 @@ import UIKit
 import ReactiveSwift
 import Result
 
-/// A dismissable presentation (e.g. navigation push, modal presentation, etc.).
+/// A dismissible presentation (e.g. navigation push, modal presentation, etc.).
 ///
 /// Presentation are single use. After the present command has been executed, a new presentation will need to be created
 /// to start a another presentation.
@@ -14,21 +14,21 @@ public class DismissablePresentation {
     public let viewController: UIViewController
 
     /// The action that begins executing the producer returned from the present producer (provided by the MakePresent
-    /// closure at intialization time). The action's execution signal completes when the signal producer's signal
+    /// closure at initialization time). The action's execution signal completes when the signal producer's signal
     /// completes.
     ///
     /// This action is only enabled when the view controller has not yet been presented.
     public let present: Action<Bool, Never, NoError>
 
     /// The action that begins executing the producer returned from the dismiss producer (provided by the MakeDismiss
-    /// closure at intialization time). The action's execution signal completes when the signal producer's signal
+    /// closure at initialization time). The action's execution signal completes when the signal producer's signal
     /// completes.
     ///
     /// This action is only enabled after presentation completes.
     public let dismiss: Action<Bool, Never, NoError>
 
     /// Sends () and then completes when the view controller dismisses (either through the the dismiss action or a value
-    /// is sent along the didDismiss signal provided at intialization).
+    /// is sent along the didDismiss signal provided at initialization).
     ///
     /// This action will be disabled while the
     public let didDismiss: Signal<(), NoError>

--- a/ReactiveExtensions/Source/Extensions/WhenTrue.swift
+++ b/ReactiveExtensions/Source/Extensions/WhenTrue.swift
@@ -3,8 +3,8 @@ import Result
 
 public extension SignalProducer where Value == Bool, Error == NoError {
 
-    /// Returns a signal producer that will subscribe to the trueSignalProducer when the reciever sends true, and will
-    /// subscribe to the falseSignalProducer when the reciever sends false.
+    /// Returns a signal producer that will subscribe to the trueSignalProducer when the receiver sends true, and will
+    /// subscribe to the falseSignalProducer when the receiver sends false.
     ///
     /// When the active signal sends a new value, the signal that was previously subscribed to will be disposed of.
     ///


### PR DESCRIPTION
Used the [Comment-Spell-Checker](https://github.com/velyan/Comment-Spell-Checker?utm_campaign=iOS%2BDev%2BWeekly&utm_medium=email&utm_source=iOS%2BDev%2BWeekly%2BIssue%2B381) Xcode plugin to resolve comment typos.